### PR TITLE
add include files to makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 run: cmake-build-debug/cleandreams_washing_machine
 	./cmake-build-debug/cleandreams_washing_machine
 
-cmake-build-debug/cleandreams_washing_machine: cleandreams_washing_machine.cpp
+cmake-build-debug/cleandreams_washing_machine: cleandreams_washing_machine.cpp includes/WashingMachine.cpp includes/WashingMachine.h includes/ServerEndpoint.cpp includes/ServerEndpoint.h includes/WashingProgram.cpp includes/WashingProgram.h
 	cmake -B cmake-build-debug
 	make -C cmake-build-debug
 


### PR DESCRIPTION
After modifying one of the files in the 'includes' folder, the make command did not rebuild the project. To fix this issue, those files were added in the dependency tree of the makefile. 